### PR TITLE
Fixed dependencies versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+PATH
+  remote: .
+  specs:
+    guard-inch (0.1.2)
+      guard (~> 2.13)
+      inch (~> 0.6, >= 0.6.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.0)
+    ffi (1.9.10)
+    formatador (0.2.5)
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    inch (0.6.4)
+      pry
+      sparkr (>= 0.2.0)
+      term-ansicolor
+      yard (~> 0.8.7.5)
+    listen (3.0.3)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    lumberjack (1.0.9)
+    method_source (0.8.2)
+    nenv (0.2.0)
+    notiffany (0.0.7)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rake (10.4.2)
+    rb-fsevent (0.9.5)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    shellany (0.0.1)
+    slop (3.6.0)
+    sparkr (0.4.1)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thor (0.19.1)
+    tins (1.5.4)
+    yard (0.8.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.5)
+  guard-inch!
+  rake (~> 10.4, >= 10.4.2)
+
+BUNDLED WITH
+   1.10.6

--- a/guard-inch.gemspec
+++ b/guard-inch.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "rake", "~> 1"
+  spec.add_development_dependency "rake", "~> 10.4", ">= 10.4.2"
 
-  spec.add_runtime_dependency "guard", "~> 0"
-  spec.add_runtime_dependency "inch", "~> 0"
+  spec.add_runtime_dependency "guard", "~> 2.13"
+  spec.add_runtime_dependency "inch", "~> 0.6", ">= 0.6.4"
 end

--- a/lib/guard/inch/version.rb
+++ b/lib/guard/inch/version.rb
@@ -2,6 +2,6 @@
 module Guard
   # The Inch Plugin Version namespace
   module InchVersion
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
Changed the way dependencies are asked for, following:
http://guides.rubygems.org/patterns/#semantic-versioning
To allow use with current guard 2.x.

Added Gemfile.lock, as taught at:
http://bundler.io/#getting-started

Also bumped patch version number, for a new release, following:
http://semver.org/
